### PR TITLE
Missing path separator

### DIFF
--- a/substrate-node-new
+++ b/substrate-node-new
@@ -38,7 +38,7 @@ function replace {
 	replace_with="$1"
 	shift
 	IFS=$'\n'
-	TEMP=$(mktemp -d "${TMPDIR:-/tmp/}.XXXXXXXXXXXX")
+	TEMP=$(mktemp -d "${TMPDIR:-/tmp}/.XXXXXXXXXXXX")
 	rmdir $TEMP
 	for item in `find . -type f`
 	do


### PR DESCRIPTION
My TMPDIR was /run/user/1000, so TEMP was set to
/run/user/1000.XXXXXXXXXXXX.