### PR TITLE
Fix typo in script usage example

### DIFF
--- a/substrate-ui-new
+++ b/substrate-ui-new
@@ -4,7 +4,7 @@ name=$1
 
 if [[ "$name" == "" || "$name" == "-"* ]]
 then
-  echo "Usage: substrate-node-new <NAME>"
+  echo "Usage: substrate-ui-new <NAME>"
   exit 1
 fi
 


### PR DESCRIPTION
In `substrate-ui-new` script there is a typo: **node** should be changed to **ui** in usage string.

Before:
`echo "Usage: substrate-node-new <NAME>"`

After fix:
`echo "Usage: substrate-ui-new <NAME>"`