### PR TITLE
Replace node_template as well

### DIFF
--- a/substrate-node-new
+++ b/substrate-node-new
@@ -57,6 +57,7 @@ replace "Template Node" "${name}"
 replace template-node "${lname//[_ ]/-}"
 replace template_node "${lname//[- ]/_}"
 replace node-template "${lname//[_ ]/-}"
+replace node_template "${lname//[_ ]/-}"
 replace Anonymous "$author"
 
 echo "${bold}Initialising repository...${normal}"


### PR DESCRIPTION
Otherwise `use node_template_runtime` will not get replaced and cause compile error

Fixes https://github.com/paritytech/substrate/issues/2241
Related: #18 