### PR TITLE
Reorder the renaming in the script

### DIFF
--- a/substrate-node-new
+++ b/substrate-node-new
@@ -56,8 +56,6 @@ function replace {
 replace "Template Node" "${name}"
 replace node-template "${lname//[_ ]/-}"
 replace node_template "${lname//[- ]/_}"
-replace template-node "${lname//[_ ]/-}"
-replace template_node "${lname//[- ]/_}"
 replace Anonymous "$author"
 
 echo "${bold}Initialising repository...${normal}"

--- a/substrate-node-new
+++ b/substrate-node-new
@@ -54,10 +54,10 @@ function replace {
 	rm -f $TEMP
 }
 replace "Template Node" "${name}"
-replace template-node "${lname//[_ ]/-}"
-replace template_node "${lname//[- ]/_}"
 replace node-template "${lname//[_ ]/-}"
 replace node_template "${lname//[- ]/_}"
+replace template-node "${lname//[_ ]/-}"
+replace template_node "${lname//[- ]/_}"
 replace Anonymous "$author"
 
 echo "${bold}Initialising repository...${normal}"


### PR DESCRIPTION
This is a half-baked patch to solve a common scenario where people name their project `substrate-node-template`, but I would prefer a solution that makes it so that we are only replace one, pretty unique string, rather than doing 2 different string renames.

Fixes https://github.com/paritytech/substrate-up/issues/22

@xlc 