### PR TITLE
Fix: substrate-node-new script doesn't exit even if a command fails

### DIFF
--- a/substrate-node-new
+++ b/substrate-node-new
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 COLOR_WHITE=$(tput setaf 7);
 COLOR_MAGENTA=$(tput setaf 5);
 FONT_BOLD=$(tput bold);

--- a/substrate-node-new
+++ b/substrate-node-new
@@ -41,10 +41,7 @@ if [ -d "$dirname" ]; then
 fi
 
 echo "${bold}  Downloading project...${normal}"
-if ! curl http://releases.parity.io/substrate/x86_64-debian:stretch/latest-v1.0/substrate-node-template.tar.gz | tar xz
-then
-	exit 1
-fi
+curl http://releases.parity.io/substrate/x86_64-debian:stretch/latest-v1.0/substrate-node-template.tar.gz | tar xz
 
 mv substrate-node-template $dirname
 


### PR DESCRIPTION
We expect the script should exit immediately if the script run offline and `curl` command fails, but the script continues running.

```sh
$ ls -a
.  ..

########################################
# Run the script OFFLINE
########################################
$ substrate-node-new hello-substrate ackintosh

  Substrate Node Template Setup
  Downloading project...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: releases.parity.io
mv: rename substrate-node-template to hello-substrate: No such file or directory
/Users/akihito1/.cargo/bin/substrate-node-new: line 49: pushd: hello-substrate: No such file or directory
Customizing project...
Initializing repository...
Initializing WebAssembly build environment...
/Users/akihito1/.cargo/bin/substrate-node-new: line 88: ./scripts/build.sh: No such file or directory
Building node...
error: could not find `Cargo.toml` in `/Users/akihito1/substrate` or any parent directory

Chain client created in hello-substrate.
To start a dev chain, run:
$ hello-substrate/target/release/hello-substrate --dev
To create a basic Bonds UI for your chain, run:
$ substrate-ui-new hello-substrate
To push to a newly created GitHub repository, inside hello-substrate, run:
$ git remote add origin git@github.com:myusername/myprojectname && git push -u origin master

/Users/akihito1/.cargo/bin/substrate-node-new: line 103: popd: directory stack empty

########################################
# The git related files are created unintentionally
########################################
$ ls -a
.  ..  .git .gitignore
```

